### PR TITLE
feat: cairo 1.0 implementation of the bto

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: all
+
+ENTRYPOINT = src
+TEST_ENTRYPOINT = .
+
+format:
+	cairo-format -r $(ENTRYPOINT)
+
+test:
+	cairo-test $(TEST_ENTRYPOINT)

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -1,0 +1,8 @@
+[package]
+name = "operator_tree"
+version = "0.1.0"
+
+# See more keys and their definitions at https://github.com/software-mansion/scarb/blob/main/scarb/src/core/manifest/toml_manifest.rs
+
+[dependencies]
+quaireaux = { git = "https://github.com/keep-starknet-strange/quaireaux.git" }

--- a/cairo_project.toml
+++ b/cairo_project.toml
@@ -1,0 +1,2 @@
+[crate_roots]
+operator_tree = "src"

--- a/protostar.toml
+++ b/protostar.toml
@@ -1,7 +1,0 @@
-[project]
-protostar-version = "0.8.1"
-lib-path = "lib"
-
-[contracts]
-main = ["lib/tree.cairo"]
-

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -1,0 +1,3 @@
+mod structures;
+
+mod tests;

--- a/src/structures.cairo
+++ b/src/structures.cairo
@@ -1,0 +1,1 @@
+mod node;

--- a/src/structures/node.cairo
+++ b/src/structures/node.cairo
@@ -1,0 +1,32 @@
+use option::OptionTrait;
+use box::BoxTrait;
+
+#[derive(Drop, Copy)]
+struct Node {
+    value: felt252,
+    left: Option::<Box::<Node>>,
+    right: Option::<Box::<Node>>,
+}
+
+trait NodeTrait {
+    fn new(value: felt252) -> Node;
+    fn insert(ref self: Node, value: felt252, to_left: bool);
+}
+
+impl NodeImpl of NodeTrait {
+    fn new(value: felt252) -> Node {
+        Node { value: value, left: Option::None(()), right: Option::None(()),  }
+    }
+
+    fn insert(ref self: Node, value: felt252, to_left: bool) {
+        match to_left {
+            bool::False(()) => {
+                self.right = Option::Some(BoxTrait::new(NodeTrait::new(value)));
+            },
+            bool::True(()) => {
+                self.left = Option::Some(BoxTrait::new(NodeTrait::new(value)));
+            },
+        }
+    }
+}
+

--- a/src/tests.cairo
+++ b/src/tests.cairo
@@ -1,0 +1,1 @@
+mod tests_structures;

--- a/src/tests/tests_structures.cairo
+++ b/src/tests/tests_structures.cairo
@@ -1,0 +1,19 @@
+// Local imports
+use operator_tree::structures::node::NodeTrait;
+
+// External imports
+use option::OptionTrait;
+use box::BoxTrait;
+
+#[test]
+#[available_gas(0x100000)]
+fn node_insert_test() {
+    // Given
+    let mut node_root = NodeTrait::new(0);
+
+    // When
+    node_root.insert(1, bool::True(()));
+
+    // Then
+    assert(node_root.left.unwrap().unbox().value == 0, 'expected left node with 1');
+}


### PR DESCRIPTION
This PR upgrades the library code to cairo 1.0:
- [ ] Upgrades library
- [ ] Redesign code to use general binary tree implementation thanks to `quaireaux` repo
- [ ] Upgrades testing 